### PR TITLE
加入驗證傳進來的日期是否正確、Readme.md 刪掉不必要的 style 區段

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,5 @@ export default {
   }
 }
 </script>
-<style lang="stylus">
-*
-  margin 0
-  padding 0
-  box-sizing border-box
-#app
-  padding 60px
-  background-color #eaeaea
-</style>
 
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-material-year-calendar",
-  "version": "0.1.10",
+  "version": "0.1.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vue-material-year-calendar",
   "main": "index.js",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",

--- a/src/App.vue
+++ b/src/App.vue
@@ -28,7 +28,7 @@ export default {
     return {
       lang: 'tw',
       year: 2019,
-      activeDates: ['2019-01-01', '2019-01-02', '2019-01-03']
+      activeDates: ['2019-01-02', '2019-01-50', '2019-01-51', '2019-01-52']
     }
   },
   methods: {

--- a/src/App.vue
+++ b/src/App.vue
@@ -33,7 +33,7 @@ export default {
   },
   methods: {
     toggleDate (dateInfo) {
-       console.log(dateInfo)
+      console.log(dateInfo)
     },
     add_sat_and_sun_of_year () {
       let theDate = dayjs(`${this.year}-01-01`)

--- a/src/App.vue
+++ b/src/App.vue
@@ -28,7 +28,7 @@ export default {
     return {
       lang: 'tw',
       year: 2019,
-      activeDates: ['2019-01-02', '2019-01-50', '2019-01-51', '2019-01-52']
+      activeDates: ['2019-03-13', '2019-12-31']
     }
   },
   methods: {

--- a/src/components/MonthCalendar.vue
+++ b/src/components/MonthCalendar.vue
@@ -79,7 +79,7 @@ export default {
       let firstDay = activeMonth.startOf('month').day() - 1
       if (firstDay < 0) firstDay += 7
       const lastDate = activeMonth.endOf('month').date()
-      const weekRow = firstDay === 6 ? 6 : 5
+      const weekRow = firstDay >= 5 ? 6 : 5
       const WEEK = 7
       let day = 0
       const fullCol = Array.from(Array(weekRow * WEEK).keys())

--- a/src/components/YearCalendar.vue
+++ b/src/components/YearCalendar.vue
@@ -51,6 +51,13 @@ export default {
   components: {
     MonthCalendar
   },
+  created () {
+    this.activeDates.forEach(el => {
+      if (this.isValidate(el) === false) {
+        throw new Error('Invalid date:' + el)
+      }
+    })
+  },
   computed: {
     month () {
       const month = {}
@@ -72,6 +79,30 @@ export default {
     }
   },
   methods: {
+    isValidate (dateString) {
+      // 測試是否為 YYYY-MM-DD 格式，以及不合理日期排除"
+
+      // https://stackoverflow.com/questions/6177975/how-to-validate-date-with-format-mm-dd-yyyy-in-javascript
+      // 由於 「^\d{4}\-\d{1,2}\-\d{1,2}$」會被ESLint 判為錯誤，所以以下暫時關閉 EsLint 對這一行的驗證
+      // eslint-disable-next-line no-useless-escape
+      if (!/^\d{4}\-\d{1,2}\-\d{1,2}$/.test(dateString)) {
+        return false
+      }
+      // Parse the date parts to integers
+      var parts = dateString.split('-')
+      var day = parseInt(parts[2], 10)
+      var month = parseInt(parts[1], 10)
+      var year = parseInt(parts[0], 10)
+      // console.log(year + month + day)
+
+      // Check the ranges of month and year
+      if (year < 1000 || year > 3000 || month === 0 || month > 12) { return false }
+      var monthLength = [ 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 ]
+      // Adjust for leap years
+      if (year % 400 === 0 || (year % 100 !== 0 && year % 4 === 0)) { monthLength[1] = 29 }
+      // Check the range of the day
+      return day > 0 && day <= monthLength[month - 1]
+    },
     changeYear (idx) {
       this.activeYear = idx + this.activeYear - 3
     },

--- a/src/components/YearCalendar.vue
+++ b/src/components/YearCalendar.vue
@@ -36,7 +36,30 @@ export default {
   props: {
     activeDates: {
       type: Array,
-      default: () => []
+      default: () => [],
+      validator: (dateArray) => {
+        let isGood = true
+        dateArray.forEach(date => {
+          // 以下程式碼參考「How to validate date with format mm/dd/yyyy in JavaScript?」in Stackoverflow
+          // 由於 「^\d{4}\-\d{1,2}\-\d{1,2}$」會被ESLint 判為錯誤，所以暫時關閉 EsLint 對下一行的驗證 by丁丁
+          // eslint-disable-next-line no-useless-escape
+          if (!/^\d{4}\-\d{1,2}\-\d{1,2}$/.test(date)) {
+            isGood = false
+          }
+          // Parse the date parts to integers
+          var parts = date.split('-')
+          var day = parseInt(parts[2], 10)
+          var month = parseInt(parts[1], 10)
+          var year = parseInt(parts[0], 10)
+
+          if (year < 1000 || year > 3000 || month === 0 || month > 12) { return false }
+          var monthLength = [ 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 ]
+          if (year % 400 === 0 || (year % 100 !== 0 && year % 4 === 0)) { monthLength[1] = 29 }
+          if (day > 0 && day <= monthLength[month - 1]) isGood = true
+          else isGood = false
+        })
+        if (isGood) { return true } else return false
+      }
     },
     // value 為從外層傳進來的 v-model="year"
     value: {
@@ -50,13 +73,6 @@ export default {
   },
   components: {
     MonthCalendar
-  },
-  created () {
-    this.activeDates.forEach(el => {
-      if (this.isValidate(el) === false) {
-        throw new Error('Invalid date:' + el)
-      }
-    })
   },
   computed: {
     month () {
@@ -79,30 +95,6 @@ export default {
     }
   },
   methods: {
-    isValidate (dateString) {
-      // 測試是否為 YYYY-MM-DD 格式，以及不合理日期排除"
-
-      // https://stackoverflow.com/questions/6177975/how-to-validate-date-with-format-mm-dd-yyyy-in-javascript
-      // 由於 「^\d{4}\-\d{1,2}\-\d{1,2}$」會被ESLint 判為錯誤，所以以下暫時關閉 EsLint 對這一行的驗證
-      // eslint-disable-next-line no-useless-escape
-      if (!/^\d{4}\-\d{1,2}\-\d{1,2}$/.test(dateString)) {
-        return false
-      }
-      // Parse the date parts to integers
-      var parts = dateString.split('-')
-      var day = parseInt(parts[2], 10)
-      var month = parseInt(parts[1], 10)
-      var year = parseInt(parts[0], 10)
-      // console.log(year + month + day)
-
-      // Check the ranges of month and year
-      if (year < 1000 || year > 3000 || month === 0 || month > 12) { return false }
-      var monthLength = [ 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 ]
-      // Adjust for leap years
-      if (year % 400 === 0 || (year % 100 !== 0 && year % 4 === 0)) { monthLength[1] = 29 }
-      // Check the range of the day
-      return day > 0 && day <= monthLength[month - 1]
-    },
     changeYear (idx) {
       this.activeYear = idx + this.activeYear - 3
     },


### PR DESCRIPTION
UI元件的錯誤處理方式：
![image](https://user-images.githubusercontent.com/1284933/54250227-e400d880-457d-11e9-9590-14c0642850fe.png)

用 props 自動的 validator 檢查輸入日期、修改 MonthCalendar 讓2018年12月31日也能出現
使用者會在console 中看到紅字。

版號有進版.