### PR TITLE
Update YearCalendar.vue

### DIFF
--- a/src/components/YearCalendar.vue
+++ b/src/components/YearCalendar.vue
@@ -26,6 +26,11 @@
         :prefixClass="prefixClass"
       >
       </month-calendar>
+      <div class="c-wrapper container__month"></div>
+      <div class="c-wrapper container__month"></div>
+      <div class="c-wrapper container__month"></div>
+      <div class="c-wrapper container__month"></div>
+      <div class="c-wrapper container__month"></div>
     </div>
   </div>
 </template>


### PR DESCRIPTION
On my monitor the month november and december are placed in another line. Both of them together have the same width as five other month together. I propose the solution that is described here [Equal width flex items](https://medium.com/developedbyjohn/equal-width-flex-items-a5ba1bfacb77)
Bugfix: The last month should have the same width as all month.