### PR TITLE
Hide weekends and sundays

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The year to be display.
    * Type: `Array of objects`  
    * Required: `true`  
    * Default: `[]`
-Your selected dates. 
+Your selected dates.
 
 If you set `className` attributes, you can customize it style in CSS.
 
@@ -170,15 +170,40 @@ Choose language to displayed.
 
 
 
-### showYearSelector 
+### showYearSelector
    * Type: `Boolean`
    * Default: `true`
 
 Show or hide the years selector on top of the calendar.
 
-ex: 
+ex:
 ```javascript
 :showYearSelector="false"
+```
+
+
+### hideSunday
+   * Type: `Boolean`
+   * Default: `false`
+
+Hide or show all sundays in the calendar.
+
+ex:
+```javascript
+:hideSunday="true"
+```
+
+
+
+### hideWeekend
+   * Type: `Boolean`
+   * Default: `false`
+
+Hide or show all weekends (saturdays and sundays) in the calendar.
+
+ex:
+```javascript
+:hideWeekend="true"
 ```
 
 
@@ -207,4 +232,3 @@ ex:
   }
 </script>
 ```
-

--- a/src/App.vue
+++ b/src/App.vue
@@ -15,10 +15,20 @@
       <option value="blue">blue</option>
       <option value="your_customized_classname">your_customized_classname</option>
     </select>
-
+    &emsp;
     <label for="">
       Show years selector?
       <input type="checkbox" v-model="showYearSelector" >
+    </label>
+    &emsp;
+    <label>
+      Hide weekend
+      <input type="checkbox" v-model="hideWeekend" >
+    </label>
+    &emsp;
+    <label>
+      Hide sunday
+      <input type="checkbox" v-model="hideSunday" >
     </label>
 
     <year-calendar
@@ -29,6 +39,8 @@
       prefixClass="your_customized_wrapper_class"
       :activeClass="activeClass"
       :showYearSelector="showYearSelector"
+      :hideWeekend="hideWeekend"
+      :hideSunday="hideSunday"
     ></year-calendar>
   </div>
 </template>
@@ -53,7 +65,9 @@ export default {
         { date: '2019-02-16', className: 'your_customized_classname' }
       ],
       activeClass: '',
-      showYearSelector: true
+      showYearSelector: true,
+      hideWeekend: false,
+      hideSunday: false
     }
   },
   methods: {

--- a/src/components/MonthCalendar.vue
+++ b/src/components/MonthCalendar.vue
@@ -47,6 +47,14 @@ export default {
     prefixClass: {
       type: String,
       default: () => 'calendar--active'
+    },
+    hideSaturday: {
+      type: Boolean,
+      default: false
+    },
+    hideSunday: {
+      type: Boolean,
+      default: false
     }
   },
   data () {

--- a/src/components/MonthCalendar.vue
+++ b/src/components/MonthCalendar.vue
@@ -47,14 +47,6 @@ export default {
     prefixClass: {
       type: String,
       default: () => 'calendar--active'
-    },
-    hideSaturday: {
-      type: Boolean,
-      default: false
-    },
-    hideSunday: {
-      type: Boolean,
-      default: false
     }
   },
   data () {

--- a/src/components/YearCalendar.vue
+++ b/src/components/YearCalendar.vue
@@ -12,7 +12,7 @@
       </span>
       <!-- <span><button @click="addYear(1)">next</button></span> -->
     </div>
-    <div class="container__months">
+    <div class="container__months" :class="{'hide-weekend': hideWeekend, 'hide-sunday': hideSunday}">
       <month-calendar
         class="container__month"
         v-for="n in 12"
@@ -95,6 +95,14 @@ export default {
     prefixClass: {
       type: String,
       default: () => 'calendar--active'
+    },
+    hideWeekend: {
+      type: Boolean,
+      default: false
+    },
+    hideSunday: {
+      type: Boolean,
+      default: false
     }
   },
   data () {
@@ -238,4 +246,21 @@ export default {
       flex: 100%
   .p-0
     padding: 0px
+</style>
+<style lang="stylus">
+.container__months.hide-sunday
+  .calendar__day:nth-of-type(7n)
+    display none !important
+  .calendar__day
+    flex 16.66% !important
+    .day
+      width 85%
+      height 85%
+
+.container__months.hide-weekend
+  .calendar__day:nth-of-type(7n), .calendar__day:nth-of-type(7n-1)
+    display none !important
+  .calendar__day
+    flex 19% !important
+
 </style>


### PR DESCRIPTION
Added the prop to hide all weekends/sundays in the calendar. This is usefull for business cases where only working days are relevant.