### PR TITLE
The fontSizeMapping has been extended

### DIFF
--- a/src/components/MonthCalendar.vue
+++ b/src/components/MonthCalendar.vue
@@ -62,7 +62,8 @@ export default {
         en: '14px',
         pt: '14px',
         de: '14px',
-        es: '14px'
+        es: '14px',
+        pl: '14px'
       }
       return fontSizeMapping[this.lang]
     },


### PR DESCRIPTION
@nono1526 I found bug in my extension of language. I've not added size for language in computed prop fontSizeMapping (MonthCalendar.vue file):
pl: '14px'

In previous manual test I had zoom settings set on 90% :/ ...but now is look like great ;)