### PR TITLE
fix: component import

### DIFF
--- a/src/components/YearCalendar.vue
+++ b/src/components/YearCalendar.vue
@@ -38,7 +38,7 @@
 
 <script>
 import dayjs from 'dayjs'
-import MonthCalendar from './MonthCalendar'
+import MonthCalendar from './MonthCalendar.vue'
 export default {
   name: 'year-calendar',
   props: {


### PR DESCRIPTION
The reason is that Vite doesn't recognize import without '.vue'